### PR TITLE
Upgrade dependencies

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,7 +3,7 @@ description "Powerful alternative to DMD's DDOC engine."
 authors "Sönke Ludwig"
 license "MIT"
 
-dependency "vibe-d:web" version=">=0.7.31 <0.10.0-0"
+dependency "vibe-d:web" version=">=0.8.0 <0.11.0-0"
 dependency "hyphenate" version="~>1.1.0"
 dependency "libdparse" version="~>0.15.4"
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -4,18 +4,23 @@
 		"botan": "1.12.19",
 		"botan-math": "1.0.3",
 		"diet-ng": "1.8.1",
-		"eventcore": "0.9.25",
+		"eventcore": "0.9.28",
 		"hyphenate": "1.1.4",
 		"libasync": "0.8.6",
 		"libdparse": "0.15.4",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "1.0.9",
+		"memutils": "1.0.10",
 		"mir-linux-kernel": "1.0.1",
-		"openssl": "3.3.0",
+		"openssl": "3.3.3",
 		"openssl-static": "1.0.2+3.0.8",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.22",
-		"vibe-core": "2.2.0",
-		"vibe-d": "0.9.6"
+		"vibe-container": "1.3.0",
+		"vibe-core": "2.8.2",
+		"vibe-d": "0.10.0",
+		"vibe-http": "1.0.0",
+		"vibe-inet": "1.0.0",
+		"vibe-serialization": "1.0.1",
+		"vibe-stream": "1.1.0"
 	}
 }


### PR DESCRIPTION
Allows building with vibe.d 0.10.x and removes support for ancient 0.7.x versions (which have also not been tested for successful builds for a long time now).